### PR TITLE
Fix highlighting when selecting a cell

### DIFF
--- a/JMStaticContentTableViewController/JMStaticContentTableViewController.m
+++ b/JMStaticContentTableViewController/JMStaticContentTableViewController.m
@@ -128,9 +128,6 @@
 }
 
 - (void) tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-	if(!tableView.editing && !tableView.allowsMultipleSelection) [tableView deselectRowAtIndexPath:indexPath animated:YES];
-	if(tableView.editing && !tableView.allowsMultipleSelectionDuringEditing) [tableView deselectRowAtIndexPath:indexPath animated:YES];
-
 	JMStaticContentTableViewSection *sectionContent = [self.staticContentSections objectAtIndex:indexPath.section];
 	JMStaticContentTableViewCell *cellContent = [sectionContent.staticContentCells objectAtIndex:indexPath.row];
 


### PR DESCRIPTION
deselectRowAtIndexPath in didSelectRowAtIndexPath call cause highlighting to animate twice when selecting the same cell.
If that's a desired behavior subclass can implement it in whenSelectedBlock
