### PR TITLE
Fix format string warning in -[JMStaticContentTableViewSection description]

### DIFF
--- a/JMStaticContentTableViewController/JMStaticContentTableViewSection.m
+++ b/JMStaticContentTableViewController/JMStaticContentTableViewSection.m
@@ -131,7 +131,7 @@
 - (NSString *) description {
     NSMutableString *str = [NSMutableString stringWithString:@"<JMStaticContentTableViewSection"];
 
-    [str appendFormat:@" sectionIndex='%d'", self.sectionIndex];
+    [str appendFormat:@" sectionIndex='%ld'", (long)self.sectionIndex];
     if(self.headerTitle) [str appendFormat:@" headerTitle='%@'", self.headerTitle];
     if(self.footerTitle) [str appendFormat:@" footerTitle='%@'", self.footerTitle];
 


### PR DESCRIPTION
This fixes the following warning:

> `JMStaticContentTableViewController/JMStaticContentTableViewSection.m:134:46: Values of type 'NSInteger' should not be used as format arguments; add an explicit cast to 'long' instead`

when building for 64-bit platforms.
