### PR TITLE
Bump podspec to v0.3.1

### DIFF
--- a/JMStaticContentTableViewController.podspec
+++ b/JMStaticContentTableViewController.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name      = 'JMStaticContentTableViewController'
-  s.version   = '0.3.0'
+  s.version   = '0.3.1'
 
   s.summary   = 'Cleanly implement a table view controller much like those in Settings.app, using a simple, convienent block-based syntax.'
   s.description = 'A subclass-able way to cleanly and neatly implement a table view controller much like those in Settings.app, with nice-looking fields to collect or display information, all using a simple and convienent block-based syntax'
 
   s.homepage  = 'https://github.com/jakemarsh/JMStaticContentTableViewController'
   s.authors   = { 'Jake Marsh' => 'jake@deallocatedobjects.com' }
-  s.source   = { :git => 'https://github.com/jakemarsh/JMStaticContentTableViewController.git', :tag => '0.3.0' }
+  s.source   = { :git => 'https://github.com/jakemarsh/JMStaticContentTableViewController.git', :tag => s.version.to_s }
 
   s.platform  = :ios
   s.requires_arc = true


### PR DESCRIPTION
Following this change, a maintainer will need to add the `0.3.1` tag and submit a new podspec to CocoaPods/Specs.
