### PR TITLE
remove resetting cell type and subviews to allow configuration block …

### DIFF
--- a/JMStaticContentTableViewController/JMStaticContentTableViewController.m
+++ b/JMStaticContentTableViewController/JMStaticContentTableViewController.m
@@ -101,10 +101,6 @@
 		cell = [[[cellContent tableViewCellSubclass] alloc] initWithStyle:cellContent.cellStyle reuseIdentifier:cellContent.reuseIdentifier];
     }
 
-	cell.imageView.image = nil;
-	cell.accessoryView = nil;
-	cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-
 	cellContent.configureBlock(cellContent, cell, indexPath);
 
     return cell;


### PR DESCRIPTION
…to take care of it, not to loose style when dequeued

I am using a custom cell which sets up subviews in constructor. This change is to preserve style that was set earlier. If someone needs this reset it could be done in the configuration block.

Thank you for the awesome pod!